### PR TITLE
Close #5 Added name attribute

### DIFF
--- a/paper-dropdown-input.html
+++ b/paper-dropdown-input.html
@@ -142,6 +142,7 @@ respectively.
           invalid="[[invalid]]"
           readonly
           disabled="[[disabled]]"
+	  name="[[name]]"
           value="[[selectedItemLabel]]"
           placeholder="[[placeholder]]"
           error-message="[[errorMessage]]"


### PR DESCRIPTION
Fixed issue #5 by adding a name attribute to the paper-input element. Not sure why this wasn't present as the element has an property defined to allow for binding with this attribute but.... eh. It's fixed now. :)