### PR TITLE
Fix Bug when we attach element multiple times

### DIFF
--- a/paper-dropdown-input.html
+++ b/paper-dropdown-input.html
@@ -477,7 +477,10 @@ respectively.
           if (contentElement && contentElement.selectedItem) {
             this._setSelectedItem(contentElement.selectedItem);
           }
-          this._setupTemplate();
+          if (!this._isSetupTemplate){
+            this._isSetupTemplate = true;
+            this._setupTemplate();
+          }
         },
         /**
          * The content element that is contained by the dropdown menu, if any.


### PR DESCRIPTION
I'm working to application with Angular 2 and Polymer 1.

I have a problem with Firefox (not chrome). The element is attached multiple times (I think is due to shady dom and Angular template engine). The result: the template which render the list of items is added multiple times.
Note: the _ready_ callback is called only once.

In fact, [_attached_ callback can be called multiple times](https://www.polymer-project.org/1.0/docs/devguide/registering-elements#lifecycle-callbacks):

> Called after the element is attached to the document. Can be called multiple times during the lifetime of an element. The first `attached` callback is guaranteed not to fire until after `ready`. 

So If we call multiple times the _attached_ callback we initialize and add template multiple times. 
I think we must initialize the template only once.

I propose a fix when the _attached_ lifecycle is called multiple times. Perhaps we can move the template setup into _ready_ callback.

best regards