### PR TITLE
Issue with Firefox (& full Polymer 2.x context)

### DIFF
--- a/paper-dropdown-input.html
+++ b/paper-dropdown-input.html
@@ -794,7 +794,7 @@ respectively.
             // 'Polymer.dom(event.detail.sourceEvent).localTarget' is erroring out with Firefox
             // when running in a full Polymer 2.x context
             var selectedItem;
-            if (event.composedPath()[0]) {
+            if (event.composedPath && event.composedPath()[0]) {
                selectedItem = event.composedPath()[0];
             }
             else {

--- a/paper-dropdown-input.html
+++ b/paper-dropdown-input.html
@@ -790,7 +790,17 @@ respectively.
           // otherwise we would always detect the edge case
           setTimeout(function () {
             if (!this.selectedItemLabel) { return }
-            var selectedItem = Polymer.dom(event.detail.sourceEvent).localTarget;
+
+            // 'Polymer.dom(event.detail.sourceEvent).localTarget' is erroring out with Firefox
+            // when running in a full Polymer 2.x context
+            var selectedItem;
+            if (event.composedPath()[0]) {
+               selectedItem = event.composedPath()[0];
+            }
+            else {
+               selectedItem = Polymer.dom(event.detail.sourceEvent).localTarget;
+            }
+
             var selectedItemLabel = selectedItem.textContent.trim() || selectedItem.label;
 
             if (selectedItemLabel !== this.selectedItemLabel) {


### PR DESCRIPTION
A null error is being rised with Firefox after the '_checkSelectChange' method runs (line var selectedItem = Polymer.dom(event.detail.sourceEvent).localTarget).
This seems happening when the component is used in a full Polymer 2.x context (not hybrid)